### PR TITLE
Add DEVELOPER_DIR support for Xcode version control

### DIFF
--- a/fastlane_core/lib/fastlane_core/helper.rb
+++ b/fastlane_core/lib/fastlane_core/helper.rb
@@ -140,7 +140,7 @@ module FastlaneCore
         return xcode_server_xcode_path
       end
 
-      return `xcode-select -p`.delete("\n") + "/"
+      return `DEVELOPER_DIR='#{ENV['DEVELOPER_DIR']}' xcode-select -p`.delete("\n") + "/"
     end
 
     def self.xcode_server?
@@ -162,7 +162,7 @@ module FastlaneCore
       end
 
       begin
-        output = `DEVELOPER_DIR='' "#{xcodebuild_path}" -version`
+        output = `DEVELOPER_DIR='#{ENV['DEVELOPER_DIR']}' "#{xcodebuild_path}" -version`
         @xcode_version = output.split("\n").first.split(' ')[1]
         @developer_dir = ENV['DEVELOPER_DIR']
       rescue => ex

--- a/fastlane_core/lib/fastlane_core/itunes_transporter.rb
+++ b/fastlane_core/lib/fastlane_core/itunes_transporter.rb
@@ -311,6 +311,7 @@ module FastlaneCore
       use_api_key = !api_key.nil?
       [
         ("API_PRIVATE_KEYS_DIR=#{api_key[:key_dir]}" if use_api_key),
+        ("DEVELOPER_DIR=#{ENV['DEVELOPER_DIR']}" if ENV['DEVELOPER_DIR']),
         "xcrun altool",
         "--upload-app",
         build_credential_params(username, password, jwt, api_key),
@@ -326,6 +327,7 @@ module FastlaneCore
       use_api_key = !api_key.nil?
       [
         ("API_PRIVATE_KEYS_DIR=#{api_key[:key_dir]}" if use_api_key),
+        ("DEVELOPER_DIR=#{ENV['DEVELOPER_DIR']}" if ENV['DEVELOPER_DIR']),
         "xcrun altool",
         "--list-providers",
         build_credential_params(username, password, jwt, api_key),
@@ -343,6 +345,7 @@ module FastlaneCore
       use_api_key = !api_key.nil?
       [
         ("API_PRIVATE_KEYS_DIR=#{api_key[:key_dir]}" if use_api_key),
+        ("DEVELOPER_DIR=#{ENV['DEVELOPER_DIR']}" if ENV['DEVELOPER_DIR']),
         "xcrun altool",
         "--validate-app",
         build_credential_params(username, password, nil, api_key),


### PR DESCRIPTION
## Summary
Add comprehensive DEVELOPER_DIR environment variable support to fastlane core for Locket's CI/CD pipeline, enabling precise control over which Xcode version is used for different operations.

## Changes
• **fastlane_core/lib/fastlane_core/helper.rb**:
  - Make `xcode-select -p` respect `DEVELOPER_DIR` environment variable
  - Make `xcodebuild -version` respect `DEVELOPER_DIR` environment variable

• **fastlane_core/lib/fastlane_core/itunes_transporter.rb**:
  - Add `DEVELOPER_DIR` to `xcrun altool --upload-app` commands
  - Add `DEVELOPER_DIR` to `xcrun altool --list-providers` commands  
  - Add `DEVELOPER_DIR` to `xcrun altool --validate-app` commands

## Use Case for Locket
This enables our CI system to:

- **Use Xcode 26 beta for non-release branches** (feature development and testing)
- **Use stable Xcode for release branches** (production deployments)
- **Seamlessly transition between Xcode versions** without manual intervention

## Integration with Locket's CI
This works with our updated `.buildkite/ios-deploy.yml` and `.buildkite/ios-test.yml` pipelines that now set:
```bash
DEVELOPER_DIR="/Applications/Xcode-26.0.0-beta.7.app"
```
for non-release branches.

## Testing
- [x] Patch applies cleanly to latest fastlane master (v2.228.0)  
- [x] Updated from our original `scripts/fastlane-patch.diff` with current line numbers
- [x] All Xcode-related commands now respect DEVELOPER_DIR
- [x] Backwards compatible - works with or without DEVELOPER_DIR set

This replaces our manual patch system with a proper fastlane fork that can be easily maintained and updated.

🤖 Generated with [Claude Code](https://claude.ai/code)